### PR TITLE
Fix comment building Elasticsearch URL

### DIFF
--- a/kibana_mapgen_PISCES_kibana.py
+++ b/kibana_mapgen_PISCES_kibana.py
@@ -18,7 +18,7 @@ def is_public_ip(ip):
         return False
 
 # ── Connect to Elasticsearch ────────────────────────────────────────────────────
-# Option A: include the scheme in the URL
+# Build the Elasticsearch host URL from the Kibana URL
 es_host = KIBANA_URL.replace('5601', '9200')  # e.g. "http://localhost:9200"
 es = Elasticsearch(
     es_host,


### PR DESCRIPTION
## Summary
- remove confusing "Option A" wording
- clarify building Elasticsearch URL from Kibana URL

## Testing
- `python3 -m py_compile kibana_mapgen_PISCES_kibana.py`

------
https://chatgpt.com/codex/tasks/task_e_68486a3a14608320896b35c9c77fc7ee