### PR TITLE
Fix IP extraction logic in VirusTotal script

### DIFF
--- a/ip_reputation_virus_total_empty.py
+++ b/ip_reputation_virus_total_empty.py
@@ -104,8 +104,8 @@ def fetch_kibana_hits(size=10000):
 def extract_ips(hits):
     ips = set()
     for hit in hits:
-        src = hit['_source'].get('source',{}).get('ip')
-        dst = hit['_source'].get('destination',{}).get('ip')
+        src = hit['_source'].get('source', {}).get('address')
+        dst = hit['_source'].get('destination', {}).get('address')
         for ip in (src, dst):
             if ip and is_public_ip(ip):
                 ips.add(ip)


### PR DESCRIPTION
## Summary
- ensure `extract_ips` gets IPs from the `address` field

## Testing
- `python -m py_compile ip_reputation_virus_total_empty.py`

------
https://chatgpt.com/codex/tasks/task_e_6848638dd6d88320b29c2f703cbb2a2a