### PR TITLE
Fix KQL dns field name

### DIFF
--- a/KQL Queries
+++ b/KQL Queries
@@ -135,6 +135,6 @@ suricata.eve.event_type:dns and
 
 clientID:("<clientID 1>" OR "<clientID 2>" ) and 
 
-Suricata.eve.dns.rrname: *.*.*.* 
+suricata.eve.dns.rrname: *.*.*.* 
 
  


### PR DESCRIPTION
## Summary
- fix a KQL query to use `suricata.eve.dns.rrname` instead of `Suricata.eve.dns.rrname`

## Testing
- `pytest -q`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6848636c863083209061616e3dc4e7cb