### PR TITLE
Fix error handling for VirusTotal responses

### DIFF
--- a/ip_reputation_virus_total_empty.py
+++ b/ip_reputation_virus_total_empty.py
@@ -46,7 +46,11 @@ def check_ip_vt(ip):
             'flagged':    flagged
         }
     else:
-        return {'ip': ip, 'error': r.json().get('error', {}).get('message', 'Unknown')}
+        try:
+            err_msg = r.json().get('error', {}).get('message', 'Unknown')
+        except ValueError:
+            err_msg = f'Status {r.status_code}'
+        return {'ip': ip, 'error': err_msg}
 
 # ── Kibana Login + Query ───────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- improve error handling when VirusTotal API does not return JSON

## Testing
- `python3 -m py_compile ip_reputation_virus_total_empty.py`
- `flake8 ip_reputation_virus_total_empty.py | head`

------
https://chatgpt.com/codex/tasks/task_e_6848626dcf8083209cf65ea55c61d924